### PR TITLE
test(animator): improve ‘animate’ function error handling, add new and refactor existing tests

### DIFF
--- a/test/animate.spec.js
+++ b/test/animate.spec.js
@@ -1,33 +1,43 @@
-import {VelocityAnimator} from '../src/animator';
-import {animationEvent} from 'aurelia-templating';
-import {initialize} from 'aurelia-pal-browser';
+import { VelocityAnimator } from '../src/animator';
+import { animationEvent } from 'aurelia-templating';
+import { initialize } from 'aurelia-pal-browser';
 
 jasmine.getFixtures().fixturesPath = 'base/test/fixtures/';
 
-describe('the animate method', () => {
-  let elem;
-  let animator;
+describe('`animate` function', () => {
   let container;
+  let animator;
+  let elemGroup;
+  let elem;
 
-  beforeAll(() => initialize());
-
-  beforeEach(() => {
-    //stop all animations running on the test element
-
+  // -------- SETUP
+  beforeAll(() => {
+    initialize();
     loadFixtures('animation.html');
-    elem = $('#test-simple').eq(0)[0];
+    elem = $('#test-animate').eq(0)[0];
+    elemGroup = $('.test-animate-group');
     container = $('#animation').eq(0)[0];
     animator = new VelocityAnimator(container);
   });
 
+  beforeEach(() => {
+    // stop all animations
+    animator.stop(elem, true); // stop all animations
+
+    // clear all styles
+    elem.removeAttribute('style');
+    for (const el of Array.from(elemGroup)) el.removeAttribute('style');
+  });
+
+  // -------- TESTS: Main
   it('returns a promise', () => {
-    let result = animator.animate(elem, 'fadeIn');
-    expect(result.then).toBeDefined();
+    const result = animator.animate(elem, 'fadeIn');
+    expect(result instanceof Promise).toBe(true);
   });
 
   it('sets isAnimating to true when the animation starts and sets it to false when the animation is done', (done) => {
     expect(animator.isAnimating).toBe(false);
-    animator.animate(elem, 'fadeIn').then(()=> {
+    animator.animate(elem, 'fadeIn').then(() => {
       expect(animator.isAnimating).toBe(false);
       done();
     });
@@ -35,9 +45,8 @@ describe('the animate method', () => {
   });
 
   it('works with a custom complete function', (done) => {
-    let complete = function() {};
-    complete = jasmine.createSpy('complete');
-    animator.animate(elem, 'fadeIn', {complete: complete}).then(()=> {
+    const complete = jasmine.createSpy('complete');
+    animator.animate(elem, 'fadeIn', { complete }).then(() => {
       expect(complete).toHaveBeenCalledWith(elem);
       done();
     });
@@ -45,44 +54,31 @@ describe('the animate method', () => {
 
   it('animates an element', (done) => {
     expect(elem.style.opacity).toBe('');
-
-    animator.animate(elem, 'fadeIn').then(()=> {
+    animator.animate(elem, 'fadeIn', { duration: 100 }).then(() => {
       expect(elem.style.opacity).toBe('1');
       done();
     });
 
-    //expect(elem.style.opacity).toBe(0);
-
-    //check the properties halfway through
-    setTimeout(()=> {
-      //get current opacity value
-      let opacity = elem.style.opacity;
-      //check if opacity was being animated
-      expect(opacity > 0, opacity < 1).toBe(true);
+    // check properties half-way through the animation
+    setTimeout(() => {
+      const opacity = elem.style.opacity;
+      expect(opacity > 0 && opacity < 1).toBe(true);
     }, 50);
   });
 
   it('animates multiple elements in parallel', (done) => {
-    let elems = container.querySelectorAll('.group1');
-
-    expect(elems[0].style.opacity).toBe('');
-
-    animator.animate(elems, 'fadeIn').then(()=> {
-      expect(elems[0].style.opacity).toBe('1');
-      expect(elems[1].style.opacity).toBe('1');
-      expect(elems[2].style.opacity).toBe('1');
-      expect(elems[3].style.opacity).toBe('1');
-
+    const elems = Array.from(elemGroup);
+    for (const el of elems) expect(el.style.opacity).toBe('');
+    animator.animate(elems, 'fadeIn', { duration: 100 }).then(() => {
+      for (const el of elems) expect(el.style.opacity).toBe('1');
       done();
     });
 
-    //check the properties halfway through
-    setTimeout(()=> {
-      for (let i = 0, l = elems.length; i < l; i++) {
-        //get current opacity value
-        let opacity = elems[0].style.opacity;
-        //check if opacity was being animated
-        expect(opacity > 0, opacity < 1).toBe(true);
+    // check properties half-way through the animation
+    setTimeout(() => {
+      for (const el of elems) {
+        const opacity = el.style.opacity;
+        expect(opacity > 0 && opacity < 1).toBe(true);
       }
     }, 50);
   });
@@ -90,189 +86,245 @@ describe('the animate method', () => {
   it('publishes an animateBegin and animateDone event', (done) => {
     let animateBeginCalled = false;
     let animateDoneCalled = false;
-    let l1 = document.addEventListener(animationEvent.animateBegin, (payload) => animateBeginCalled = true);
-    let l2 = document.addEventListener(animationEvent.animateDone, () => animateDoneCalled = true);
+    const beginListener = document.addEventListener(animationEvent.animateBegin, (payload) => animateBeginCalled = true);
+    const doneListener = document.addEventListener(animationEvent.animateDone, () => animateDoneCalled = true);
 
-    animator.animate(elem, 'fadeIn').then(() => {
+    animator.animate(elem, 'fadeIn', { duration: 100 }).then(() => {
       expect(animateDoneCalled).toBe(true);
-      document.removeEventListener(animationEvent.animateDone, l2, false);
+      document.removeEventListener(animationEvent.animateDone, doneListener, false);
       done();
     });
 
     expect(animateBeginCalled).toBe(true);
-    document.removeEventListener(animationEvent.animateBegin, l1, false);
+    document.removeEventListener(animationEvent.animateBegin, beginListener, false);
   });
 
-  //------------------- Test Various Arguments
+  it('does not publish an animateBegin and animateDone event when `silent` is true', (done) => {
+    let animateBeginCalled = false;
+    let animateDoneCalled = false;
+    const beginListener = document.addEventListener(animationEvent.animateBegin, (payload) => animateBeginCalled = true);
+    const doneListener = document.addEventListener(animationEvent.animateDone, () => animateDoneCalled = true);
 
+    animator.animate(elem, 'fadeIn', { duration: 100 }, true).then(() => {
+      expect(animateDoneCalled).toBe(false);
+      document.removeEventListener(animationEvent.animateDone, doneListener, false);
+      done();
+    });
+
+    expect(animateBeginCalled).toBe(false);
+    document.removeEventListener(animationEvent.animateBegin, beginListener, false);
+  });
+
+  // -------- TESTS: Argument tests
   it('rejects the promise when nothing is passed', (done) => {
-    animator.animate().catch((e)=> {
+    animator.animate().then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
-  // first argument
+  // ---- TESTS: First argument (element)
+  it('resolves the promise with a NodeList when first argument is a selector that does not match anything', (done) => {
+    animator.animate('element-that-does-not-exist', 'fadeIn').then(result => {
+      expect(result instanceof NodeList).toBe(true);
+      expect(result.length === 0).toBe(true);
+      done();
+    }).catch(() => done.fail());
+  });
+
+  it('resolves the promise with a NodeList when first argument is a selector that matches elements', (done) => {
+    animator.animate('.test-animate-group', 'fadeIn').then(result => {
+      expect(result instanceof NodeList).toBe(true);
+      expect(result.length).toBe(5);
+      for (const el of Array.from(result)) expect(el.style.opacity).toBe('1');
+      done();
+    }).catch(() => done.fail());
+  });
+
+  it('resolves the promise with an Array when first argument is an HTMLElement', (done) => {
+    animator.animate(elem, 'fadeIn').then(result => {
+      expect(Array.isArray(result)).toBe(true);
+      done();
+    }).catch(() => done.fail());
+  });
+
+  it('resolves the promise with a NodeList when first argument is a NodeList', (done) => {
+    const nodeList = container.querySelectorAll('.test-animate-group');
+    animator.animate(nodeList, 'fadeIn').then(result => {
+      expect(result instanceof NodeList).toBe(true);
+      done();
+    }).catch(() => done.fail());
+  });
+
+  it('resolves the promise with an Array when first argument is an Array', (done) => {
+    const array = Array.from(container.querySelectorAll('.group1'));
+    animator.animate(array, 'fadeIn').then(result => {
+      expect(Array.isArray(result)).toBe(true);
+      done();
+    }).catch(() => done.fail());
+  });
+
   it('rejects the promise with an Error when first argument is undefined', (done) => {
-    animator.animate(undefined, 'fadeIn').catch((e)=> {
+    animator.animate(undefined, 'fadeIn').then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when first argument is null', (done) => {
-    animator.animate(null, 'fadeIn').catch((e)=> {
+    animator.animate(null, 'fadeIn').then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when first argument is a boolean', (done) => {
-    animator.animate(null, false).catch((e)=> {
+    animator.animate(null, false).then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when first argument is an integer', (done) => {
-    animator.animate(null, 10).catch((e)=> {
+    animator.animate(null, 10).then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when first argument is an array', (done) => {
-    animator.animate(null, [1]).catch((e)=> {
+    animator.animate(null, [1]).then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
-  it('resolves the promise with a NodeList when first argument is a selector that doesnt match anything', (done) => {
-    animator.animate('test', 'fadeIn').then((result)=> {
-      expect(result instanceof NodeList).toBe(true);
-      expect(result.length === 0).toBe(true);
-      done();
-    }).catch((e)=> {
-      expect(e instanceof Error).toBe(null);
-      done();
-    });
-  });
-
-  it('resolves the promise with a NodeList when first argument is a selector that matches elements', (done) => {
-    animator.animate('.group1', 'fadeIn').then((result)=> {
-      expect(result instanceof NodeList).toBe(true);
-      expect(result.length > 0).toBe(true);
-      for (let i = 0; i < result.length; i++) expect(result[i].style.opacity).toBe('1');
-      done();
-    }).catch((e)=> {
-      expect(e instanceof Error).toBe(null);
-      done();
-    });
-  });
-
-  it('resolves the promise with an Array when first argument is an HTMLElement', (done) => {
-    animator.animate(elem, {}).catch((e)=> {
-      expect(e instanceof Error).toBe(true);
-      done();
-    });
-  });
-
-  it('resolves the promise with a NodeList when first argument is a NodeList', (done) => {
-    animator.animate(container.querySelectorAll('.group1'), 'fadeIn').then(result=> {
-      expect(result instanceof NodeList).toBe(true);
-      done();
-    });
-  });
-
-  it('resolves the promise with an Array when first argument is an Array', (done) => {
-    let elems = container.querySelectorAll('.group1');
-    let els = [];
-    for (let i = 0; i < elems.length; i++) {
-      els.push(elems[i]);
-    }
-    animator.animate(els, 'fadeIn').then(result=> {
-      expect(Array.isArray(result)).toBe(true);
-      done();
-    });
-  });
-
-  // second argument
+  // ---- TESTS: Second argument (name or properties)
   it('resolves the promise with an Array when second argument is an effect name that is registered', (done) => {
-    animator.animate(elem, 'fadeIn').then(result=> {
+    animator.animate(elem, 'fadeIn').then(result => {
       expect(Array.isArray(result)).toBe(true);
       done();
-    });
-  });
-
-  it('rejects the promise with an Error when second argument is an effect name that has not been registered', (done) => {
-    animator.animate(elem, 'wrongEffectName').catch((e)=> {
-      expect(e instanceof Error).toBe(true);
-      done();
-    });
+    }).catch(() => done.fail());
   });
 
   it('resolves the promise with an Array when second argument is an object', (done) => {
-    animator.animate(elem, {opacity: 1}).then(result=> {
+    animator.animate(elem, { opacity: 1 }).then(result => {
       expect(Array.isArray(result)).toBe(true);
+      done();
+    }).catch(() => done.fail());
+  });
+
+  it('rejects the promise with an Error when second argument is an effect name that has not been registered', (done) => {
+    animator.animate(elem, 'effectThatDoesNotExist').then(() => done.fail()).catch(e => {
+      expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when second argument is an empty object', (done) => {
-    animator.animate(elem, {}).catch((e)=> {
+    animator.animate(elem, {}).then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when second argument is omitted', (done) => {
-    animator.animate(elem).catch((e)=> {
+    animator.animate(elem).then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when second argument is undefined', (done) => {
-    animator.animate(elem, undefined).catch((e)=> {
+    animator.animate(elem, undefined).then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when second argument is null', (done) => {
-    animator.animate(elem, null).catch((e)=> {
+    animator.animate(elem, null).then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when second argument is a boolean', (done) => {
-    animator.animate(elem, true).catch((e)=> {
+    animator.animate(elem, true).then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
   it('rejects the promise with an Error when second argument is an array', (done) => {
-    animator.animate(elem, [1, 2]).catch((e)=> {
+    animator.animate(elem, [1, 2]).then(() => done.fail()).catch(e => {
       expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
-  // third argument
-  it('resolves the promise with an Array when third argument is an array', (done) => {
-    animator.animate(elem, {opacity: 1}, [0]).then(result=> {
+  // ---- TESTS: Third argument (options)
+  it('resolves the promise with an Array when third argument is an Object', (done) => {
+    animator.animate(elem, { opacity: 1 }, {}).then(result => {
       expect(Array.isArray(result)).toBe(true);
+      done();
+    }).catch(() => done.fail());
+  });
+
+  it('resolves the promise with an Array when third argument is null', (done) => {
+    animator.animate(elem, { opacity: 1 }, null).then(result => {
+      expect(Array.isArray(result)).toBe(true);
+      done();
+    }).catch(() => done.fail());
+  });
+
+  it('resolves the promise with an Array when third argument is undefined', (done) => {
+    animator.animate(elem, { opacity: 1 }, undefined).then(result => {
+      expect(Array.isArray(result)).toBe(true);
+      done();
+    }).catch(() => done.fail());
+  });
+
+  it('rejects the promise with an Error when third argument is an array', (done) => {
+    animator.animate(elem, { opacity: 1 }, [0]).then(() => done.fail()).catch(e => {
+      expect(e instanceof Error).toBe(true);
       done();
     });
   });
 
-  it('resolves the promise with an Array when third argument is a string', (done) => {
-    animator.animate(elem, {opacity: 1}, 'bla').then(result=> {
-      expect(Array.isArray(result)).toBe(true);
+  it('rejects the promise with an Error when third argument is a string', (done) => {
+    animator.animate(elem, { opacity: 1 }, 'fadeIn').then(() => done.fail()).catch(e => {
+      expect(e instanceof Error).toBe(true);
       done();
     });
+  });
+
+  it('rejects the promise with an Error when third argument is a number', (done) => {
+    animator.animate(elem, { opacity: 1 }, 6).then(() => done.fail()).catch(e => {
+      expect(e instanceof Error).toBe(true);
+      done();
+    });
+  });
+
+  it('rejects the promise with an Error when third argument is a boolean', (done) => {
+    animator.animate(elem, { opacity: 1 }, true).catch(e => {
+      expect(e instanceof Error).toBe(true);
+      done();
+    });
+  });
+
+  // ---- TESTS: Fourth argument (silent)
+  it('resolves the promise with an Array when fourth argument is a boolean', (done) => {
+    animator.animate(elem, { opacity: 1 }, {}, undefined).then(result => {
+      expect(Array.isArray(result)).toBe(true);
+      done();
+    }).catch(() => done.fail());
+  });
+
+  it('resolves the promise with an Array when fourth argument is undefined', (done) => {
+    animator.animate(elem, { opacity: 1 }, {}, undefined).then(result => {
+      expect(Array.isArray(result)).toBe(true);
+      done();
+    }).catch(() => done.fail());
   });
 });

--- a/test/fixtures/animation.html
+++ b/test/fixtures/animation.html
@@ -1,10 +1,18 @@
 <style type="text/css">
-  section.au-animate {
-    opacity: 0;
-  }
+  section.au-animate { opacity: 0; }
 </style>
 
 <div id="animation">
+
+  <!-- Animate function tests -->
+  <div id="test-animate">test-animate</div>
+
+  <div class="test-animate-group">test-animate-group (1)</div>
+  <div class="test-animate-group">test-animate-group (2)</div>
+  <div class="test-animate-group">test-animate-group (3)</div>
+  <div class="test-animate-group">test-animate-group (4)</div>
+  <div class="test-animate-group">test-animate-group (5)</div>
+  <!-- END Animate function tests -->
 
   <div id="test-simple" class="group1"></div>
   <div id="test-simple2" class="group1"></div>


### PR DESCRIPTION
Documented 'silent' parameter.
Added tests for 'silent' parameter.
Improved error handling inside 'animate' function.
Refactored existing 'animate' tests and added a bunch of new ones.
Also added some spaces for cleaner code.